### PR TITLE
Formatting

### DIFF
--- a/Interface.js
+++ b/Interface.js
@@ -17,7 +17,7 @@ Interface.prototype.homonymList = (homonyms) => {
     choices: [...choices, 'Exit app'],
   }).then((answer) => {
     if (answer.homonym === 'Exit app') {
-      console.log('\n> You have exited Homonym Helper. Goodbye!');
+      console.log(chalk `{green ${'\n> You have exited Homonym Helper. Goodbye!'}}`);
       return null;
     }
     this.currentHomonyms = answer.homonym.substring(1, answer.homonym.length - 1).split(', ');
@@ -78,9 +78,9 @@ Interface.prototype.homonymFormatter = (origWord, homonyms) => {
 Interface.prototype.questionsList = (currentHomonyms, textFragments) => {
   const questions = [];
   textFragments.forEach((currentArr) => {
-    const formattedHomonyms = self.homonymFormatter(currWordArr[currWordIndex], currentHomonyms);
     const currWordArr = currentArr[0];
     const currWordIndex = currentArr[1];
+    const formattedHomonyms = self.homonymFormatter(currWordArr[currWordIndex], currentHomonyms);
     currentHomonyms.forEach((currentHomonym, i) => {
       if (currWordArr[currWordIndex].toLowerCase().match(formattedHomonyms[i].toLowerCase()) !== null) {
         // Had to call again from within inner loop, need to optimize; currently O(n^3)

--- a/Interface.js
+++ b/Interface.js
@@ -50,42 +50,49 @@ Interface.prototype.sentenceFragment = (textArr) => {
   }, []);
 };
 
-Interface.prototype.wordCaseMatcher = (origWord, homonyms) => {
-  const origWordArr = origWord.split('');
+Interface.prototype.homonymFormatter = (origWord, homonyms) => {
+  // Function identifies if you are using apostrophies
+  // or single quotes and adjusts the homonym list.
+  const wordArr = origWord.split('');
   const formattedHomonyms = homonyms;
-  if (origWordArr[0] === origWordArr[0].toUpperCase()) {
-    homonyms.forEach((homonym, index) => {
-      const homonymArr = homonym.split('');
+  formattedHomonyms.forEach((homonym, index) => {
+    const homonymArr = homonym.split('');
+    // if contractions don't match, replace with apostrophe or single quote
+    // apostrophe ( ’ ) is default.
+    if (wordArr.indexOf('\'') > -1 && homonymArr.indexOf('’') > -1) {
+      homonymArr[homonymArr.indexOf('’')] = '\'';
+    } else {
+      homonymArr[homonymArr.indexOf('\'')] = '’';
+    }
+    // if first letter doesn't match, replace with proper case
+    if (wordArr[0] === wordArr[0].toUpperCase()) {
       homonymArr[0] = homonymArr[0].toUpperCase();
-      formattedHomonyms[index] = homonymArr.join('');
-    });
-  } else {
-    homonyms.forEach((homonym, index) => {
-      formattedHomonyms[index] = homonym.toLowerCase();
-    });
-  }
+    } else {
+      homonymArr[0] = homonymArr[0].toLowerCase();
+    }
+    formattedHomonyms[index] = homonymArr.join('');
+  });
   return formattedHomonyms;
 };
 
 Interface.prototype.questionsList = (currentHomonyms, textFragments) => {
   const questions = [];
   textFragments.forEach((currentArr) => {
-    let formattedHomonyms = currentHomonyms;
+    const formattedHomonyms = self.homonymFormatter(currWordArr[currWordIndex], currentHomonyms);
     const currWordArr = currentArr[0];
     const currWordIndex = currentArr[1];
-    currentHomonyms.forEach((current) => {
-      if (currWordArr[currWordIndex].toLowerCase().match(current.toLowerCase()) !== null) {
-        // functions in loops are funny; use an IIFE for proper output
-        formattedHomonyms = () => self.wordCaseMatcher(currWordArr[currWordIndex], currentHomonyms); 
+    currentHomonyms.forEach((currentHomonym, i) => {
+      if (currWordArr[currWordIndex].toLowerCase().match(formattedHomonyms[i].toLowerCase()) !== null) {
+        // Had to call again from within inner loop, need to optimize; currently O(n^3)
+        const answerChoices = () => self.homonymFormatter(currWordArr[currWordIndex], currentHomonyms);
         const questionObj = {
           type: 'list',
           name: `${currentArr[2]}`,
           message: chalk `Please select replacement homonym: {yellow ${currWordArr.slice(0, currWordIndex).join(' ')}}${currWordIndex !== 0 ? ' ' : ''}{green.bold ${currWordArr[currWordIndex]}} {yellow ${currWordArr.slice(currWordIndex + 1, currWordArr.length).join(' ')}}`,
-          choices: formattedHomonyms,
+          choices: answerChoices,
         };
         questions.push(questionObj);
       }
-      formattedHomonyms = currentHomonyms;
     });
   });
   return questions;

--- a/Interface.js
+++ b/Interface.js
@@ -55,13 +55,13 @@ Interface.prototype.homonymFormatter = (origWord, homonyms) => {
   // or single quotes and adjusts the homonym list.
   const wordArr = origWord.split('');
   const formattedHomonyms = homonyms;
-  formattedHomonyms.forEach((homonym, index) => {
+  homonyms.forEach((homonym, index) => {
     const homonymArr = homonym.split('');
     // if contractions don't match, replace with apostrophe or single quote
     // apostrophe ( ’ ) is default.
     if (wordArr.indexOf('\'') > -1 && homonymArr.indexOf('’') > -1) {
       homonymArr[homonymArr.indexOf('’')] = '\'';
-    } else {
+    } else if (homonymArr.indexOf('\'') > -1) {
       homonymArr[homonymArr.indexOf('\'')] = '’';
     }
     // if first letter doesn't match, replace with proper case
@@ -70,12 +70,23 @@ Interface.prototype.homonymFormatter = (origWord, homonyms) => {
     } else {
       homonymArr[0] = homonymArr[0].toLowerCase();
     }
+    // if word ends with punctuation
+    if (homonymArr[homonymArr.length - 1] === '?' || homonymArr[homonymArr.length - 1] === '!' || homonymArr[homonymArr.length - 1] === '.') {
+      homonymArr.pop();
+    } else if (wordArr.indexOf('?') > -1) {
+      homonymArr.push('?');
+    } else if (wordArr.indexOf('!') > -1) {
+      homonymArr.push('!');
+    } else if (wordArr.indexOf('.') > -1) {
+      homonymArr.push('.');
+    }
     formattedHomonyms[index] = homonymArr.join('');
   });
   return formattedHomonyms;
 };
 
-Interface.prototype.questionsList = (currentHomonyms, textFragments) => {
+Interface.prototype.questionsList = (homonyms, textFragments) => {
+  const currentHomonyms = homonyms;
   const questions = [];
   textFragments.forEach((currentArr) => {
     const currWordArr = currentArr[0];

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const Interface = require('./Interface');
 const FileHandler = require('./FileHandler');
 const inquirer = require('inquirer');
+const chalk = require('chalk');
 
 // 1. Open file from args, store in a variable
 // 2. Load homonym dictionary and ask user to pick homonym to checks, store in a variable
@@ -23,9 +24,12 @@ const app = {
   runApp(folder, fileName) {
     const IO = new Interface();
     const UserFile = new FileHandler();
+    console.log(chalk `{green.bold ${'\n=================================='}}`);
+    console.log(chalk `{green.bold ${'=== Welcome to Homonym Helper! ==='}}`);
+    console.log(chalk `{green.bold ${'=================================='}}`);
 
     UserFile.getFile(folder, fileName, 'currentFileText')
-    .then(data => console.log(`\n=== your file output is below ===\n\n${data}`))
+    .then(data => console.log(chalk `{green ${'\nyour file output is below!\n\n\n\n'}}${data}`))
     .then(() => UserFile.getFile('ref', 'homonyms.txt', 'currentHomonyms'))
     .then(homonyms => IO.homonymList(homonyms))
     .then((chosenHomonyms) => {
@@ -55,7 +59,7 @@ const app = {
       if (answer.status === 'Yes') {
         this.start();
       } else {
-        console.log('\n> You have exited Homonym Helper. Goodbye!');
+        console.log(chalk `{green ${'\n> You have exited Homonym Helper. Goodbye!'}}`);
       }
     }))
     .catch(error => console.error(error));

--- a/input/testing.txt
+++ b/input/testing.txt
@@ -1,9 +1,9 @@
 Testing with Intentional Errors:
 
-You lost you’re bet, because Portugal won they’re first Euro 2016 title.
+You lost you’re bet, because Portugal won they're first Euro 2016 title.
 Their is a legend of a hidden temple.
-Say, what have you got they’re?
+Say, what have you got They’re?
 We never did find out if there going to open the donut shop.
 You’re powers are no match for my radioactive puffin.
-If you click on this article, your not going to believe this ad supported list, which now comes with 30-second air horn blasting through you’re speakers!
+If you click on this article, your not going to believe this ad supported list, which now comes with 30-second air horn blasting through you're speakers!
 

--- a/ref/homonyms.txt
+++ b/ref/homonyms.txt
@@ -1,2 +1,2 @@
-"there, their, they're"
-"your, you're"
+"there, their, they’re"
+"your, you’re"


### PR DESCRIPTION
Solved #1 . Issue was that `testing.txt` had apostrophes ("they’re") because it was written in TextEdit, while `homonyms.txt` had single quotes ("they're") because it was written in VSCode. Rewrote code to detect for such usage and keep it consistent.

Also added detection for ending punctuation to the same function so that the homonyms can have the same ending punctuation as the original word, e.g. "they're?" will have "there?" and "their?" as homonym options.